### PR TITLE
Use conventional workflow files

### DIFF
--- a/.github/workflows/npm-publish-from-label.yml
+++ b/.github/workflows/npm-publish-from-label.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   npm-publish-from-label:
-    uses: infrastructure-blocks/npm-publish-from-label-workflow/.github/workflows/npm-publish-from-label.yml@v1
+    uses: infrastructure-blocks/npm-publish-from-label-workflow/.github/workflows/workflow.yml@v1
     secrets:
       github-pat: ${{ secrets.PAT }}
       npm-token: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/trigger-update-from-template.yml
+++ b/.github/workflows/trigger-update-from-template.yml
@@ -13,6 +13,6 @@ permissions:
 
 jobs:
   trigger-update-from-template:
-    uses: infrastructure-blocks/trigger-update-from-template-workflow/.github/workflows/trigger-update-from-template.yml@v1
+    uses: infrastructure-blocks/trigger-update-from-template-workflow/.github/workflows/workflow.yml@v1
     secrets:
       github-pat: ${{ secrets.PAT }}

--- a/.github/workflows/update-from-template.yml
+++ b/.github/workflows/update-from-template.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   merge-template:
-    uses: infrastructure-blocks/merge-template-workflow/.github/workflows/merge-template.yml@v1
+    uses: infrastructure-blocks/merge-template-workflow/.github/workflows/workflow.yml@v1
     with:
       labels: ${{ inputs.labels }}
     secrets:


### PR DESCRIPTION
- Closes infrastructure-blocks/git-tag-semver-from-label-workflow#17
- Closes infrastructure-blocks/merge-template-workflow#24
- Closes infrastructure-blocks/trigger-update-from-template-workflow#19
- Closes infrastructure-blocks/npm-publish-from-label-workflow#12
