### PR TITLE
Provide commonjs alternatives automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-node_modules/
+/node_modules/
 /lib/
-coverage/
-.nyc_output/
+/coverage/
 infra-blocks-*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@infra-blocks/ts-lib-template",
+  "name": "@infra-blocks/lib-template",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@infra-blocks/ts-lib-template",
+      "name": "@infra-blocks/lib-template",
       "version": "0.0.0",
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,18 @@
   "license": "ISC",
   "author": "",
   "type": "module",
-  "exports": "./lib/index.js",
+  "exports": {
+    "import": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js",
+    "default": "./lib/esm/index.js"
+  },
   "files": [
-    "lib/**/*.{js,d.ts,map}"
+    "lib/**/*.{js,cjs,mjs,json,d.ts,map}"
   ],
   "scripts": {
-    "build": "npm run clean && tsc --project tsconfig.build.json",
+    "prebuild": "npm run clean",
+    "build": "tsc -b tsconfig.build.json tsconfig.build.cjs.json",
+    "postbuild": "scripts/post-build.sh",
     "clean": "rm -rf lib && rm -f infra-blocks-*.tgz",
     "compile": "tsc",
     "lint": "eslint --ext .js,.cjs,.mjs,.json,.ts --max-warnings 0 .",

--- a/scripts/package.cjs.json
+++ b/scripts/package.cjs.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/scripts/post-build.sh
+++ b/scripts/post-build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+cp ./scripts/package.cjs.json ./lib/cjs/package.json

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./lib/cjs"
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "noEmit": false
+    "declaration": true,
+    "noEmit": false,
+    "outDir": "./lib/esm",
+    "sourceMap": true
   },
   "include": [
     "src/**/*.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,10 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "skipLibCheck": true,
     "module": "node16",
-    "outDir": "lib",
+    "outDir": "./lib/compile",
     "strict": true,
     "target": "esnext",
-    "sourceMap": true,
     "lib": [
       "esnext"
     ],


### PR DESCRIPTION
- TS configs for CJS & ESM separated
- Outputs in two different folders
- CJS package.json stub to override package type and force
commonjs.
- Provide 2 sets of type declarations. This makes it easier to
work with module "node16" config in typescript. Typescript uses the
closest package.json to determine the module type of the type
declarations. So, even if we provide the "types"
keyword in package.json, it can only be right for one type of import:
CJS or MJS, whichever the nearest package.json says.
- package.json exports
- Closes #9