### PR TITLE
Fix CJS build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/node_modules/
+node_modules/
 /lib/
 /coverage/
 infra-blocks-*.tgz

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "prebuild": "npm run clean",
-    "build": "tsc -b tsconfig.build.json tsconfig.build.cjs.json",
+    "build": "tsc -b tsconfig.build.esm.json tsconfig.build.cjs.json",
     "postbuild": "scripts/post-build.sh",
     "clean": "rm -rf lib && rm -f infra-blocks-*.tgz",
     "compile": "tsc",

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node16",
     "outDir": "./lib/cjs"
   }
 }

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib/esm"
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "declaration": true,
     "noEmit": false,
-    "outDir": "./lib/esm",
     "sourceMap": true
   },
   "include": [


### PR DESCRIPTION
- Pinned module resolution to node16 when building CJS output. This is required
as otherwise, the default is "node" and it's not funtional with libraries generated
the way this library is (and probably other stuff too).
- Split the typescript build config a little more