### PR TITLE
adding main field in the package.json to support legacy usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "require": "./lib/cjs/index.js",
     "default": "./lib/esm/index.js"
   },
+  "main": "./lib/cjs/index.js",
   "files": [
     "lib/**/*.{js,cjs,mjs,json,d.ts,map}"
   ],


### PR DESCRIPTION
- This is especially triggered when using `node10` as a module
resolution, such as when trying to outoput cjs from modern
typescript.
